### PR TITLE
drop: x86 and x86_64 support

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -1,7 +1,7 @@
 ROOT_DIR ?= .
 BUILD_TYPE ?= debug
 API_LEVEL ?= 25
-ARCHS ?= arm64-v8a armeabi-v7a x86 x86_64
+ARCHS ?= arm64-v8a armeabi-v7a
 ARCH ?= arm64-v8a
 
 VER_NAME ?= v1.0.0
@@ -34,8 +34,6 @@ BUILD_DIR ?= $(ROOT_DIR)/build
 
 TARGET_arm64-v8a = aarch64-linux-android$(API_LEVEL)
 TARGET_armeabi-v7a = armv7a-linux-androideabi$(API_LEVEL)
-TARGET_x86 = i686-linux-android$(API_LEVEL)
-TARGET_x86_64 = x86_64-linux-android$(API_LEVEL)
 
 CC_ARCH = $(CC) --target=$(TARGET_$(ARCH)) --sysroot=$(SYSROOT)
 

--- a/module/src/customize.sh
+++ b/module/src/customize.sh
@@ -39,11 +39,15 @@ else
 fi
 
 # check architecture
-if [ "$ARCH" != "arm" ] && [ "$ARCH" != "arm64" ] && [ "$ARCH" != "x86" ] && [ "$ARCH" != "x64" ]; then
-  abort "! Unsupported platform: $ARCH"
-else
-  ui_print "- Device platform: $ARCH"
+if [ "$ARCH" = "x86" ] || [ "$ARCH" = "x64" ]; then
+  abort "! x86 / x86_64 devices are not supported by VexZygisk"
 fi
+
+if [ "$ARCH" != "arm" ] && [ "$ARCH" != "arm64" ]; then
+  abort "! Unsupported platform: $ARCH"
+fi
+
+ui_print "- Device platform: $ARCH"
 
 ui_print "- Extracting verify.sh"
 unzip -o "$ZIPFILE" 'verify.sh' -d "$TMPDIR" >&2
@@ -104,20 +108,10 @@ unzip -o "$ZIPFILE" "webroot/*" -x "*.sha256" -d "$MODPATH"
 #         use, so injecting it only costs performance and stability for no real gain. The
 #         32-bit binaries are therefore installed on 32-bit only devices solely.
 case "$ARCH" in
-  x86)
-    ARCH_BITS=32
-    ARCH_LIB_DIR=lib
-    ARCH_ABI=x86
-    ;;
   arm)
     ARCH_BITS=32
     ARCH_LIB_DIR=lib
     ARCH_ABI=armeabi-v7a
-    ;;
-  x64)
-    ARCH_BITS=64
-    ARCH_LIB_DIR=lib64
-    ARCH_ABI=x86_64
     ;;
   *)
     ARCH_BITS=64

--- a/zygiskd/src/zygiskd.c
+++ b/zygiskd/src/zygiskd.c
@@ -37,10 +37,6 @@ struct Context {
   #define ARCH_STR "arm64-v8a"
 #elif __arm__
   #define ARCH_STR "armeabi-v7a"
-#elif __x86_64__
-  #define ARCH_STR "x86_64"
-#elif __i386__
-  #define ARCH_STR "x86"
 #else
   #error "Unsupported architecture"
   #define ARCH_STR "unknown"


### PR DESCRIPTION
x86 devices are a thing of the past and no longer worth carrying. Support is removed at the build and installation level:

- build: the x86 and x86_64 targets are dropped from ARCHS and their NDK target triples removed from common.mk
- zygiskd: the x86 ARCH_STR branches are gone, unknown architectures now hit the existing #error
- module: the installer aborts on x86/x64 devices and their extraction cases are removed

Architecture-specific code paths inside the loader are kept: they are generic per-arch compilation branches of the injection machinery, add nothing to the ARM builds, and keep the door open should x86 ever matter again.