### PR TITLE
fix: harden module reload and drop Magisk-era leftovers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ $(MODULE_DONE): $(LOADER_DONE) $(ZYGISKD_DONE) $(MODULE_INPUTS)
 	    module/src/module.prop > $(MODULE_OUT)/module.prop
 
 	@echo "Customizing scripts..."
-	@for script in customize.sh post-fs-data.sh service.sh uninstall.sh; do \
+	@for script in customize.sh post-fs-data.sh uninstall.sh; do \
 		sed -e 's/@DEBUG@/$(if $(filter debug,$(BUILD_TYPE)),true,false)/g' \
 		    -e 's/@MIN_KSU_VERSION@/$(MIN_KSU_VERSION)/g'                   \
 		    -e 's/@MIN_KSUD_VERSION@/$(MIN_KSUD_VERSION)/g'                 \

--- a/loader/src/injector/hook.c
+++ b/loader/src/injector/hook.c
@@ -943,6 +943,10 @@ static bool load_modules_only(void) {
     return false;
   }
 
+  /* INFO: Reset the counter first: a second pass must not write past the fresh
+             buffer or leak the previous allocation. */
+  zygisk_module_length = 0;
+
   zygisk_modules = (struct rezygisk_module *)malloc(ms.modules_count * sizeof(struct rezygisk_module));
   if (!zygisk_modules) {
     LOGE("Failed to allocate memory for modules");
@@ -1271,6 +1275,7 @@ static void rz_cleanup(struct zygisk_context *ctx) {
   for (size_t i = 0; i < zygisk_module_length; i++) {
     memset(&zygisk_modules[i], 0, sizeof(zygisk_modules[i]));
   }
+  zygisk_module_length = 0;
 
   enable_unloader = true;
   pthread_mutex_destroy(&ctx->hook_info_lock);

--- a/module/src/customize.sh
+++ b/module/src/customize.sh
@@ -75,7 +75,6 @@ fi
 ui_print "- Extracting module files"
 extract "$ZIPFILE" 'module.prop'     "$MODPATH"
 extract "$ZIPFILE" 'post-fs-data.sh' "$MODPATH"
-extract "$ZIPFILE" 'service.sh'      "$MODPATH"
 extract "$ZIPFILE" 'uninstall.sh'    "$MODPATH"
 extract "$ZIPFILE" 'rezygisk.sh' "/data/adb/post-fs-data.d/"
 

--- a/module/src/post-fs-data.sh
+++ b/module/src/post-fs-data.sh
@@ -3,9 +3,6 @@
 set -e
 
 MODDIR=${0%/*}
-if [ "$ZYGISK_ENABLED" ]; then
-  exit 0
-fi
 
 cd "$MODDIR"
 

--- a/module/src/service.sh
+++ b/module/src/service.sh
@@ -1,3 +1,0 @@
-#!/system/bin/sh
-
-exit 0


### PR DESCRIPTION
Audit pass over the current tree:

- hook.c: reset zygisk_module_length before loading modules and again after cleanup, so a second load_modules_only cannot leak the previous allocation or write past the freshly allocated buffer
- post-fs-data.sh: drop the ZYGISK_ENABLED early exit, a leftover of the Magisk coexistence logic that can never be set anymore
- service.sh: remove the empty script along with its Makefile and installer references